### PR TITLE
feat: implement ListClusterSnapshots with real data processing

### DIFF
--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 
@@ -18,6 +19,11 @@ func (s *S) ListClusterSnapshots(
 	ctx context.Context,
 	req *v1.ListClusterSnapshotsRequest,
 ) (*v1.ListClusterSnapshotsResponse, error) {
+	const (
+		defaultDuration = 24 * time.Hour
+		defaultInterval = time.Hour
+	)
+
 	authInfo, ok := auth.ExtractUserInfoFromContext(ctx)
 	if !ok {
 		return nil, status.Errorf(codes.Unauthenticated, "failed to extract user info from context")
@@ -33,15 +39,20 @@ func (s *S) ListClusterSnapshots(
 		return nil, status.Errorf(codes.NotFound, "no cluster snapshots found for tenant %s", authInfo.TenantID)
 	}
 
+	endTime := time.Now().Truncate(defaultInterval)
+	startTime := endTime.Add(-1 * defaultDuration)
+
 	// List all cluster snapshot histories for each snapshot.
-	var allHistories []*store.ClusterSnapshotHistory
+	var hs []*store.ClusterSnapshotHistory
 	for _, c := range cs {
-		histories, err := s.store.ListClusterSnapshotHistories(c.ClusterID)
+		chs, err := s.store.ListClusterSnapshotHistories(c.ClusterID, startTime.Add(defaultInterval), endTime)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to list cluster snapshot histories for cluster %s: %s", c.ClusterID, err)
 		}
-		allHistories = append(allHistories, histories...)
+		hs = append(hs, chs...)
 	}
+
+	fmt.Printf("FOUND %d snapshots for cluster\n", len(hs))
 
 	// Construct datapoints.
 	//
@@ -53,76 +64,69 @@ func (s *S) ListClusterSnapshots(
 	//    The grouping key is nil as we don't support grouping by any key yet.
 	//    Take average if there is more than one snapshot from the same cluster in the interval.
 
-	endTime := time.Now()
-	startTime := endTime.Add(-24 * time.Hour) // Default to the last 24 hours.
-
-	// Filter histories within the time range and sort by CreatedAt
-	var filteredHistories []*store.ClusterSnapshotHistory
-	for _, h := range allHistories {
-		if !h.CreatedAt.Before(startTime) && h.CreatedAt.Before(endTime) {
-			filteredHistories = append(filteredHistories, h)
-		}
-	}
-
-	sort.Slice(filteredHistories, func(i, j int) bool {
-		return filteredHistories[i].CreatedAt.Before(filteredHistories[j].CreatedAt)
+	sort.Slice(hs, func(i, j int) bool {
+		return hs[i].HistoryCreatedAt.Before(hs[j].HistoryCreatedAt)
 	})
 
-	// Group by 1-hour intervals
-	datapoints := make([]*v1.ListClusterSnapshotsResponse_Datapoint, 0)
-	hourInterval := time.Hour
-
 	// Group histories by hourly intervals in a single pass
-	intervalBuckets := make(map[time.Time][]*store.ClusterSnapshotHistory)
-	for _, h := range filteredHistories {
-		intervalStart := h.CreatedAt.Truncate(hourInterval)
-		intervalBuckets[intervalStart] = append(intervalBuckets[intervalStart], h)
+	intervalBuckets := make(map[int64][]*store.ClusterSnapshotHistory)
+	for _, h := range hs {
+		t := h.HistoryCreatedAt.Truncate(defaultInterval)
+		intervalBuckets[t.Unix()] = append(intervalBuckets[t.Unix()], h)
 	}
 
 	// Process each interval bucket
-	for current := startTime.Truncate(hourInterval); current.Before(endTime); current = current.Add(hourInterval) {
-		ihs := intervalBuckets[current]
-		var totalGPUCapacity int32
-		if len(ihs) > 0 {
-			// Group by cluster ID and calculate average GPU capacity per cluster
-			clusterGPUSums := make(map[string]int32)
-			clusterCounts := make(map[string]int)
-
-			for _, h := range ihs {
-				var snapshot workerv1.ClusterSnapshot
-				if err := proto.Unmarshal(h.Message, &snapshot); err != nil {
-					continue // Skip invalid messages
-				}
-
-				var totalGPU int32
-				for _, node := range snapshot.Nodes {
-					totalGPU += node.GpuCapacity
-				}
-
-				clusterGPUSums[h.ClusterID] += totalGPU
-				clusterCounts[h.ClusterID]++
-			}
-
-			// Calculate total GPU capacity (sum of averages from each cluster)
-			for clusterID, sum := range clusterGPUSums {
-				count := clusterCounts[clusterID]
-				totalGPUCapacity += sum / int32(count) // Average for this cluster
-			}
+	var dps []*v1.ListClusterSnapshotsResponse_Datapoint
+	for t := startTime; t.Before(endTime); t = t.Add(defaultInterval) {
+		hs := intervalBuckets[t.Unix()]
+		v, err := calculateTotalGPUCapacity(hs)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to calculate total gpu capacity: %s", err)
 		}
-
-		datapoint := &v1.ListClusterSnapshotsResponse_Datapoint{
-			Timestamp: current.Unix(),
+		dp := &v1.ListClusterSnapshotsResponse_Datapoint{
+			Timestamp: t.Unix(),
 			Values: []*v1.ListClusterSnapshotsResponse_Value{
 				{
 					GroupingKey: nil,
-					GpuCapacity: totalGPUCapacity,
+					GpuCapacity: v,
 				},
 			},
 		}
-		datapoints = append(datapoints, datapoint)
+		dps = append(dps, dp)
 	}
 
 	return &v1.ListClusterSnapshotsResponse{
-		Datapoints: datapoints,
+		Datapoints: dps,
 	}, nil
+}
+
+func calculateTotalGPUCapacity(hs []*store.ClusterSnapshotHistory) (int32, error) {
+	var totalGPUCapacity int32
+
+	// Group by cluster ID and calculate average GPU capacity per cluster
+	clusterGPUSums := make(map[string]int32)
+	clusterCounts := make(map[string]int)
+
+	for _, h := range hs {
+		var snapshot v1.ClusterSnapshot
+		if err := proto.Unmarshal(h.Message, &snapshot); err != nil {
+			return 0, err
+		}
+
+		var totalGPU int32
+		for _, node := range snapshot.Nodes {
+			totalGPU += node.GpuCapacity
+		}
+
+		clusterGPUSums[h.ClusterID] += totalGPU
+		clusterCounts[h.ClusterID]++
+	}
+
+	// Calculate total GPU capacity (sum of averages from each cluster)
+	for clusterID, sum := range clusterGPUSums {
+		count := clusterCounts[clusterID]
+		totalGPUCapacity += sum / int32(count) // Average for this cluster
+	}
+
+	return totalGPUCapacity, nil
 }

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"time"
 
@@ -45,14 +44,12 @@ func (s *S) ListClusterSnapshots(
 	// List all cluster snapshot histories for each snapshot.
 	var hs []*store.ClusterSnapshotHistory
 	for _, c := range cs {
-		chs, err := s.store.ListClusterSnapshotHistories(c.ClusterID, startTime.Add(defaultInterval), endTime)
+		chs, err := s.store.ListClusterSnapshotHistories(c.ClusterID, startTime.Add(-1*defaultInterval), endTime)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to list cluster snapshot histories for cluster %s: %s", c.ClusterID, err)
 		}
 		hs = append(hs, chs...)
 	}
-
-	fmt.Printf("FOUND %d snapshots for cluster\n", len(hs))
 
 	// Construct datapoints.
 	//

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -72,18 +72,16 @@ func (s *S) ListClusterSnapshots(
 	datapoints := make([]*v1.ListClusterSnapshotsResponse_Datapoint, 0)
 	hourInterval := time.Hour
 
+	// Group histories by hourly intervals in a single pass
+	intervalBuckets := make(map[time.Time][]*store.ClusterSnapshotHistory)
+	for _, h := range filteredHistories {
+		intervalStart := h.CreatedAt.Truncate(hourInterval)
+		intervalBuckets[intervalStart] = append(intervalBuckets[intervalStart], h)
+	}
+
+	// Process each interval bucket
 	for current := startTime.Truncate(hourInterval); current.Before(endTime); current = current.Add(hourInterval) {
-		intervalEnd := current.Add(hourInterval)
-
-		// Collect all histories in this interval
-		// TODO(kenji): Make this more efficient.
-		var ihs []*store.ClusterSnapshotHistory
-		for _, h := range filteredHistories {
-			if !h.CreatedAt.Before(current) && h.CreatedAt.Before(intervalEnd) {
-				ihs = append(ihs, h)
-			}
-		}
-
+		ihs := intervalBuckets[current]
 		var totalGPUCapacity int32
 		if len(ihs) > 0 {
 			// Group by cluster ID and calculate average GPU capacity per cluster

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -2,12 +2,16 @@ package server
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	v1 "github.com/llmariner/cluster-monitor/api/v1"
+	workerv1 "github.com/llmariner/cluster-monitor/api/v1"
+	"github.com/llmariner/cluster-monitor/server/internal/store"
 	"github.com/llmariner/rbac-manager/pkg/auth"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // ListClusterSnapshots lists the cluster snapshots.
@@ -31,12 +35,20 @@ func (s *S) ListClusterSnapshots(
 	}
 
 	// List all cluster snapshot histories for each snapshot.
+	var allHistories []*store.ClusterSnapshotHistory
+	for _, c := range cs {
+		histories, err := s.store.ListClusterSnapshotHistories(c.ClusterID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to list cluster snapshot histories for cluster %s: %s", c.ClusterID, err)
+		}
+		allHistories = append(allHistories, histories...)
+	}
 
 	// Construct datapoints.
 	//
 	// 1. Sort cluster snapshot histories by its CreatedAt in ascending order.
 	// 2. Group them by an interval of 1 hour.
-	// 3. For each internal, consturct a datapoint (v1.ListClusterSnapshotsResponse_Datapoint).
+	// 3. For each interval, construct a datapoint (v1.ListClusterSnapshotsResponse_Datapoint).
 	//    The timestamp of the datapoint is the start of the interval.
 	//    The values of the datapoint is currently sum of GPU capacities of all cluster snapshots in the interval.
 	//    The grouping key is nil as we don't support grouping by any key yet.
@@ -45,18 +57,78 @@ func (s *S) ListClusterSnapshots(
 	endTime := time.Now()
 	startTime := endTime.Add(-24 * time.Hour) // Default to the last 24 hours.
 
-	// Fake value for testing.
-	return &v1.ListClusterSnapshotsResponse{
-		Datapoints: []*v1.ListClusterSnapshotsResponse_Datapoint{
-			{
-				Timestamp: time.Now().Unix(),
-				Values: []*v1.ListClusterSnapshotsResponse_Value{
-					{
-						GroupingKey: nil,
-						GpuCapacity: 1,
-					},
+	// Filter histories within the time range and sort by CreatedAt
+	var filteredHistories []*store.ClusterSnapshotHistory
+	for _, h := range allHistories {
+		if h.CreatedAt.After(startTime) && h.CreatedAt.Before(endTime) {
+			filteredHistories = append(filteredHistories, h)
+		}
+	}
+
+	sort.Slice(filteredHistories, func(i, j int) bool {
+		return filteredHistories[i].CreatedAt.Before(filteredHistories[j].CreatedAt)
+	})
+
+	// Group by 1-hour intervals
+	datapoints := make([]*v1.ListClusterSnapshotsResponse_Datapoint, 0)
+	hourInterval := time.Hour
+
+	for current := startTime.Truncate(hourInterval); current.Before(endTime); current = current.Add(hourInterval) {
+		intervalEnd := current.Add(hourInterval)
+
+		// Collect all histories in this interval
+		var intervalHistories []*store.ClusterSnapshotHistory
+		for _, h := range filteredHistories {
+			if !h.CreatedAt.Before(current) && h.CreatedAt.Before(intervalEnd) {
+				intervalHistories = append(intervalHistories, h)
+			}
+		}
+
+		if len(intervalHistories) == 0 {
+			continue
+		}
+
+		// Group by cluster ID and calculate average GPU capacity per cluster
+		clusterGpuSums := make(map[string]int32)
+		clusterCounts := make(map[string]int)
+
+		for _, h := range intervalHistories {
+			var snapshot workerv1.ClusterSnapshot
+			if err := proto.Unmarshal(h.Message, &snapshot); err != nil {
+				continue // Skip invalid messages
+			}
+
+			var totalGpu int32
+			for _, node := range snapshot.Nodes {
+				totalGpu += node.GpuCapacity
+			}
+
+			clusterGpuSums[h.ClusterID] += totalGpu
+			clusterCounts[h.ClusterID]++
+		}
+
+		// Calculate total GPU capacity (sum of averages from each cluster)
+		var totalGpuCapacity int32
+		for clusterID, sum := range clusterGpuSums {
+			count := clusterCounts[clusterID]
+			if count > 0 {
+				totalGpuCapacity += sum / int32(count) // Average for this cluster
+			}
+		}
+
+		datapoint := &v1.ListClusterSnapshotsResponse_Datapoint{
+			Timestamp: current.Unix(),
+			Values: []*v1.ListClusterSnapshotsResponse_Value{
+				{
+					GroupingKey: nil,
+					GpuCapacity: totalGpuCapacity,
 				},
 			},
-		},
+		}
+		datapoints = append(datapoints, datapoint)
+	}
+
+	return &v1.ListClusterSnapshotsResponse{
+		Datapoints: datapoints,
 	}, nil
 }

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -77,14 +77,14 @@ func (s *S) ListClusterSnapshots(
 		intervalEnd := current.Add(hourInterval)
 
 		// Collect all histories in this interval
-		var intervalHistories []*store.ClusterSnapshotHistory
+		var ihs []*store.ClusterSnapshotHistory
 		for _, h := range filteredHistories {
 			if !h.CreatedAt.Before(current) && h.CreatedAt.Before(intervalEnd) {
-				intervalHistories = append(intervalHistories, h)
+				ihs = append(ihs, h)
 			}
 		}
 
-		if len(intervalHistories) == 0 {
+		if len(ihs) == 0 {
 			continue
 		}
 
@@ -92,7 +92,7 @@ func (s *S) ListClusterSnapshots(
 		clusterGPUSums := make(map[string]int32)
 		clusterCounts := make(map[string]int)
 
-		for _, h := range intervalHistories {
+		for _, h := range ihs {
 			var snapshot workerv1.ClusterSnapshot
 			if err := proto.Unmarshal(h.Message, &snapshot); err != nil {
 				continue // Skip invalid messages

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	v1 "github.com/llmariner/cluster-monitor/api/v1"
-	workerv1 "github.com/llmariner/cluster-monitor/api/v1"
 	"github.com/llmariner/cluster-monitor/server/internal/store"
 	"github.com/llmariner/rbac-manager/pkg/auth"
 	"google.golang.org/grpc/codes"

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -85,35 +85,33 @@ func (s *S) ListClusterSnapshots(
 			}
 		}
 
-		if len(ihs) == 0 {
-			continue
-		}
-
-		// Group by cluster ID and calculate average GPU capacity per cluster
-		clusterGPUSums := make(map[string]int32)
-		clusterCounts := make(map[string]int)
-
-		for _, h := range ihs {
-			var snapshot workerv1.ClusterSnapshot
-			if err := proto.Unmarshal(h.Message, &snapshot); err != nil {
-				continue // Skip invalid messages
-			}
-
-			var totalGPU int32
-			for _, node := range snapshot.Nodes {
-				totalGPU += node.GpuCapacity
-			}
-
-			clusterGPUSums[h.ClusterID] += totalGPU
-			clusterCounts[h.ClusterID]++
-		}
-
-		// Calculate total GPU capacity (sum of averages from each cluster)
 		var totalGPUCapacity int32
-		for clusterID, sum := range clusterGPUSums {
-			count := clusterCounts[clusterID]
-			if count > 0 {
-				totalGPUCapacity += sum / int32(count) // Average for this cluster
+		if len(ihs) > 0 {
+			// Group by cluster ID and calculate average GPU capacity per cluster
+			clusterGPUSums := make(map[string]int32)
+			clusterCounts := make(map[string]int)
+
+			for _, h := range ihs {
+				var snapshot workerv1.ClusterSnapshot
+				if err := proto.Unmarshal(h.Message, &snapshot); err != nil {
+					continue // Skip invalid messages
+				}
+
+				var totalGPU int32
+				for _, node := range snapshot.Nodes {
+					totalGPU += node.GpuCapacity
+				}
+
+				clusterGPUSums[h.ClusterID] += totalGPU
+				clusterCounts[h.ClusterID]++
+			}
+
+			// Calculate total GPU capacity (sum of averages from each cluster)
+			for clusterID, sum := range clusterGPUSums {
+				count := clusterCounts[clusterID]
+				if count > 0 {
+					totalGPUCapacity += sum / int32(count) // Average for this cluster
+				}
 			}
 		}
 

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -89,7 +89,7 @@ func (s *S) ListClusterSnapshots(
 		}
 
 		// Group by cluster ID and calculate average GPU capacity per cluster
-		clusterGpuSums := make(map[string]int32)
+		clusterGPUSums := make(map[string]int32)
 		clusterCounts := make(map[string]int)
 
 		for _, h := range intervalHistories {
@@ -98,21 +98,21 @@ func (s *S) ListClusterSnapshots(
 				continue // Skip invalid messages
 			}
 
-			var totalGpu int32
+			var totalGPU int32
 			for _, node := range snapshot.Nodes {
-				totalGpu += node.GpuCapacity
+				totalGPU += node.GpuCapacity
 			}
 
-			clusterGpuSums[h.ClusterID] += totalGpu
+			clusterGPUSums[h.ClusterID] += totalGPU
 			clusterCounts[h.ClusterID]++
 		}
 
 		// Calculate total GPU capacity (sum of averages from each cluster)
-		var totalGpuCapacity int32
-		for clusterID, sum := range clusterGpuSums {
+		var totalGPUCapacity int32
+		for clusterID, sum := range clusterGPUSums {
 			count := clusterCounts[clusterID]
 			if count > 0 {
-				totalGpuCapacity += sum / int32(count) // Average for this cluster
+				totalGPUCapacity += sum / int32(count) // Average for this cluster
 			}
 		}
 
@@ -121,7 +121,7 @@ func (s *S) ListClusterSnapshots(
 			Values: []*v1.ListClusterSnapshotsResponse_Value{
 				{
 					GroupingKey: nil,
-					GpuCapacity: totalGpuCapacity,
+					GpuCapacity: totalGPUCapacity,
 				},
 			},
 		}

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -109,9 +109,7 @@ func (s *S) ListClusterSnapshots(
 			// Calculate total GPU capacity (sum of averages from each cluster)
 			for clusterID, sum := range clusterGPUSums {
 				count := clusterCounts[clusterID]
-				if count > 0 {
-					totalGPUCapacity += sum / int32(count) // Average for this cluster
-				}
+				totalGPUCapacity += sum / int32(count) // Average for this cluster
 			}
 		}
 

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -59,7 +59,7 @@ func (s *S) ListClusterSnapshots(
 	// Filter histories within the time range and sort by CreatedAt
 	var filteredHistories []*store.ClusterSnapshotHistory
 	for _, h := range allHistories {
-		if h.CreatedAt.After(startTime) && h.CreatedAt.Before(endTime) {
+		if !h.CreatedAt.Before(startTime) && h.CreatedAt.Before(endTime) {
 			filteredHistories = append(filteredHistories, h)
 		}
 	}

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -2,11 +2,12 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	v1 "github.com/llmariner/cluster-monitor/api/v1"
 	"github.com/llmariner/rbac-manager/pkg/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // ListClusterSnapshots lists the cluster snapshots.
@@ -14,10 +15,35 @@ func (s *S) ListClusterSnapshots(
 	ctx context.Context,
 	req *v1.ListClusterSnapshotsRequest,
 ) (*v1.ListClusterSnapshotsResponse, error) {
-	_, ok := auth.ExtractUserInfoFromContext(ctx)
+	authInfo, ok := auth.ExtractUserInfoFromContext(ctx)
 	if !ok {
-		return nil, fmt.Errorf("failed to extract user info from context")
+		return nil, status.Errorf(codes.Unauthenticated, "failed to extract user info from context")
 	}
+
+	// Query all snapshots of the tenant.
+	cs, err := s.store.ListClusterSnapshotsByTenantID(authInfo.TenantID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to list cluster snapshots: %s", err)
+	}
+
+	if len(cs) == 0 {
+		return nil, status.Errorf(codes.NotFound, "no cluster snapshots found for tenant %s", authInfo.TenantID)
+	}
+
+	// List all cluster snapshot histories for each snapshot.
+
+	// Construct datapoints.
+	//
+	// 1. Sort cluster snapshot histories by its CreatedAt in ascending order.
+	// 2. Group them by an interval of 1 hour.
+	// 3. For each internal, consturct a datapoint (v1.ListClusterSnapshotsResponse_Datapoint).
+	//    The timestamp of the datapoint is the start of the interval.
+	//    The values of the datapoint is currently sum of GPU capacities of all cluster snapshots in the interval.
+	//    The grouping key is nil as we don't support grouping by any key yet.
+	//    Take average if there is more than one snapshot from the same cluster in the interval.
+
+	endTime := time.Now()
+	startTime := endTime.Add(-24 * time.Hour) // Default to the last 24 hours.
 
 	// Fake value for testing.
 	return &v1.ListClusterSnapshotsResponse{

--- a/server/internal/server/cluster_snapshot.go
+++ b/server/internal/server/cluster_snapshot.go
@@ -77,6 +77,7 @@ func (s *S) ListClusterSnapshots(
 		intervalEnd := current.Add(hourInterval)
 
 		// Collect all histories in this interval
+		// TODO(kenji): Make this more efficient.
 		var ihs []*store.ClusterSnapshotHistory
 		for _, h := range filteredHistories {
 			if !h.CreatedAt.Before(current) && h.CreatedAt.Before(intervalEnd) {

--- a/server/internal/server/cluster_snapshot_test.go
+++ b/server/internal/server/cluster_snapshot_test.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/llmariner/cluster-monitor/api/v1"
+	"github.com/llmariner/cluster-monitor/server/internal/store"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestListClusterSnapshots(t *testing.T) {
+	marshalProto := func(t *testing.T, msg *v1.ClusterSnapshot) []byte {
+		data, err := proto.Marshal(msg)
+		assert.NoError(t, err)
+		return data
+	}
+
+	now := time.Now()
+	nowT := now.Truncate(time.Hour)
+
+	generateDatapoints := func(vals []int32) []*v1.ListClusterSnapshotsResponse_Datapoint {
+		dps := make([]*v1.ListClusterSnapshotsResponse_Datapoint, 0, len(vals))
+		for i := 0; i < 24; i++ {
+			timestamp := nowT.Add(-time.Duration(24-i) * time.Hour).Unix()
+			dps = append(dps, &v1.ListClusterSnapshotsResponse_Datapoint{
+				Timestamp: timestamp,
+				Values:    []*v1.ListClusterSnapshotsResponse_Value{{GpuCapacity: vals[i]}},
+			})
+		}
+		return dps
+	}
+
+	tcs := []struct {
+		name  string
+		setup func(*testing.T, *store.S)
+		req   *v1.ListClusterSnapshotsRequest
+		want  *v1.ListClusterSnapshotsResponse
+	}{
+		{
+			name: "success",
+			setup: func(t *testing.T, st *store.S) {
+				cs := []*store.ClusterSnapshot{
+					{
+						ClusterID: "cid0",
+						TenantID:  defaultTenantID,
+					},
+					{
+						ClusterID: "cid1",
+						TenantID:  defaultTenantID,
+					},
+				}
+
+				for _, c := range cs {
+					err := st.CreateOrUpdateClusterSnapshot(c)
+					assert.NoError(t, err)
+				}
+
+				chs := []*store.ClusterSnapshotHistory{
+					{
+						ClusterID:        "cid0",
+						HistoryCreatedAt: now.Add(-3 * time.Hour),
+						Message: marshalProto(t, &v1.ClusterSnapshot{
+							Nodes: []*v1.ClusterSnapshot_Node{
+								{
+									GpuCapacity: 1,
+								},
+								{
+									GpuCapacity: 2,
+								},
+							},
+						}),
+					},
+					{
+						ClusterID:        "cid0",
+						HistoryCreatedAt: now.Add(-2 * time.Hour),
+						Message: marshalProto(t, &v1.ClusterSnapshot{
+							Nodes: []*v1.ClusterSnapshot_Node{
+								{
+									GpuCapacity: 1,
+								},
+								{
+									GpuCapacity: 2,
+								},
+							},
+						}),
+					},
+					{
+						ClusterID:        "cid0",
+						HistoryCreatedAt: now.Add(-2*time.Hour + 1*time.Minute),
+						Message: marshalProto(t, &v1.ClusterSnapshot{
+							Nodes: []*v1.ClusterSnapshot_Node{
+								{
+									GpuCapacity: 1,
+								},
+								{
+									GpuCapacity: 2,
+								},
+							},
+						}),
+					},
+				}
+				for _, ch := range chs {
+					err := st.CreateClusterSnapshotHistory(ch)
+					assert.NoError(t, err)
+				}
+			},
+			req: &v1.ListClusterSnapshotsRequest{},
+			want: &v1.ListClusterSnapshotsResponse{
+				Datapoints: generateDatapoints([]int32{
+					0, 0, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0,
+					0, 0, 0, 3, 3, 0,
+				}),
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			st, tearDown := store.NewTest(t)
+			defer tearDown()
+			tc.setup(t, st)
+
+			srv := New(st, testr.New(t))
+			ctx := fakeAuthInto(context.Background())
+
+			got, err := srv.ListClusterSnapshots(ctx, tc.req)
+			assert.NoError(t, err)
+
+			assert.Truef(t, proto.Equal(got, tc.want), cmp.Diff(got, tc.want, protocmp.Transform()))
+		})
+	}
+
+}

--- a/server/internal/server/cluster_telemetry.go
+++ b/server/internal/server/cluster_telemetry.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"time"
 
 	v1 "github.com/llmariner/cluster-monitor/api/v1"
 	"github.com/llmariner/cluster-monitor/server/internal/store"
@@ -58,8 +59,9 @@ func (ws *WS) processClusterSnapshot(
 	}
 
 	csh := &store.ClusterSnapshotHistory{
-		ClusterID: clusterInfo.ClusterID,
-		Message:   msg,
+		ClusterID:        clusterInfo.ClusterID,
+		Message:          msg,
+		HistoryCreatedAt: time.Now(),
 	}
 	if err := ws.store.CreateClusterSnapshotHistory(csh); err != nil {
 		return err

--- a/server/internal/server/cluster_telemetry_test.go
+++ b/server/internal/server/cluster_telemetry_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	v1 "github.com/llmariner/cluster-monitor/api/v1"
@@ -43,7 +44,8 @@ func TestListClusters(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, defaultClusterID, cs.ClusterID)
 
-	hs, err := st.ListClusterSnapshotHistories(cs.ClusterID)
+	now := cs.CreatedAt
+	hs, err := st.ListClusterSnapshotHistories(cs.ClusterID, now.Add(-1*time.Hour), now.Add(1*time.Hour))
 	assert.NoError(t, err)
 	assert.Len(t, hs, 1)
 


### PR DESCRIPTION
## Summary
- Replace fake implementation with actual data retrieval from cluster snapshot histories
- Add time-based filtering for last 24 hours with proper interval grouping
- Implement protobuf unmarshaling and GPU capacity aggregation

## Changes
- **Data Retrieval**: Fetch cluster snapshot histories for all clusters belonging to the tenant
- **Time Filtering**: Filter histories to last 24 hours and sort by creation time
- **Interval Grouping**: Group data into 1-hour intervals as specified in the original comments
- **GPU Calculation**: Extract GPU capacity from protobuf messages and calculate averages per cluster per interval
- **Error Handling**: Add proper error handling for database operations and protobuf unmarshaling

## Test plan
- [x] Code compiles successfully (`go build ./server/...`)
- [x] All existing tests pass (`make test`)
- [x] Linting passes for Go code (`make lint`)
- [ ] Manual testing with real cluster snapshot data
- [ ] Verify time-based filtering works correctly
- [ ] Confirm GPU capacity aggregation logic

🤖 Generated with [Claude Code](https://claude.ai/code)